### PR TITLE
Keep the native terminal active when enabling gfxterm

### DIFF
--- a/util/grub.d/00_header.in
+++ b/util/grub.d/00_header.in
@@ -221,7 +221,7 @@ case x${GRUB_TERMINAL_OUTPUT} in
   ;;
   x*)
     cat << EOF
-terminal_output ${GRUB_TERMINAL_OUTPUT}
+terminal_output --append ${GRUB_TERMINAL_OUTPUT}
 EOF
   ;;
 esac


### PR DESCRIPTION
grub-mkconfig will set GRUB_TERMINAL_OUTPUT to "gfxterm" unless the user
has overridden it. On EFI systems, this will stop output from going to the
default "console" terminal. When the EFI fw console is configured to output to
both serial and video, this will cause GRUB to only display on video - while
continuing to accept input from both video and serial.

Instead of switching from "console" to "gfxterm", let's output to both.